### PR TITLE
Adicionando ao RelevanciaList as filtragens

### DIFF
--- a/index_connection/views.py
+++ b/index_connection/views.py
@@ -1,9 +1,14 @@
 from rest_framework import generics
 from .models import Relevancia_site
 from .serializers import IndexSerializer
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters
 
 
 class RelevanciaList(generics.ListCreateAPIView):
     queryset = Relevancia_site.objects.all()
     serializer_class = IndexSerializer
-
+    filter_backends = (DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter,)
+    search_fields = ('site',)
+    filter_fields = '__all__'
+    ordering_fields = '__all__'


### PR DESCRIPTION
Foi adicionado os backends de filtragens: DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter,
1 - Colocado o searchfields para buscas 'LIKE' no campo site.
2 - Colocado o flter_fields para todos os campos e o ordering_fields também.